### PR TITLE
Add VGUI2 scaling

### DIFF
--- a/src/game/client/gameui/CMakeLists.txt
+++ b/src/game/client/gameui/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_sources(
 	CMakeLists.txt
+	gameui_scale.cpp
+	gameui_scale.h
 	gameui_test_panel.cpp
 	gameui_test_panel.h
 	gameui_viewport.cpp

--- a/src/game/client/gameui/filedialog/CFileBrowser.cpp
+++ b/src/game/client/gameui/filedialog/CFileBrowser.cpp
@@ -141,6 +141,8 @@ CFileBrowser::CFileBrowser(vgui2::Panel *pParent)
 
 void CFileBrowser::ApplySchemeSettings( vgui2::IScheme *pScheme )
 {
+	CGameUIViewport::ComputeGUIScale();
+
 	BaseClass::ApplySchemeSettings( pScheme );
 
 	// load the password icon

--- a/src/game/client/gameui/gameui_scale.cpp
+++ b/src/game/client/gameui/gameui_scale.cpp
@@ -1,0 +1,33 @@
+#include <vgui/ISurface.h>
+#include "gameui_scale.h"
+
+float g_flGUIScaleX = 1.0f;
+float g_flGUIScaleY = 1.0f;
+
+void CGameUIViewport::ComputeGUIScale()
+{
+	int screenWide, screenTall;
+	vgui2::surface()->GetScreenSize(screenWide, screenTall);
+
+	g_flGUIScaleX = screenWide / 1920.0f;
+	g_flGUIScaleY = screenTall / 1080.0f;
+}
+
+void vgui2::ScaleAllChildren(vgui2::Panel* parent, float scaleX, float scaleY)
+{
+	if (!parent)
+		return;
+
+	for (int i = 0; i < parent->GetChildCount(); i++)
+	{
+		vgui2::Panel *child = parent->GetChild(i);
+		if (!child)
+			continue;
+
+		int x, y, w, h;
+		child->GetPos(x, y);
+		child->GetSize(w, h);
+		child->SetPos(static_cast<int>(x * scaleX), static_cast<int>(y * scaleY));
+		child->SetSize(static_cast<int>(x * scaleX), static_cast<int>(h * scaleY));
+	}
+}

--- a/src/game/client/gameui/gameui_scale.h
+++ b/src/game/client/gameui/gameui_scale.h
@@ -1,0 +1,8 @@
+#ifndef GAMEUI_SCALE_H
+#define GAMEUI_SCALE_H
+#include <vgui_controls/EditablePanel.h>
+#include "gameui_viewport.h"
+namespace vgui2 {
+	void ScaleAllChildren(vgui2::Panel *parent, float scaleX, float scaleY);
+}
+#endif

--- a/src/game/client/gameui/gameui_test_panel.cpp
+++ b/src/game/client/gameui/gameui_test_panel.cpp
@@ -52,6 +52,7 @@ CGameUITestPanel::CGameUITestPanel(vgui2::Panel *pParent)
 	m_pText->SetUnusedScrollbarInvisible(true);
 
 	SetScheme(CGameUIViewport::Get()->GetScheme());
+	CGameUIViewport::ComputeGUIScale();
 	InvalidateLayout();
 }
 

--- a/src/game/client/gameui/gameui_viewport.cpp
+++ b/src/game/client/gameui/gameui_viewport.cpp
@@ -6,6 +6,7 @@
 #include "cl_util.h"
 #include "client_vgui.h"
 #include "gameui_viewport.h"
+#include "gameui_scale.h"
 #include "gameui_test_panel.h"
 #include "serverbrowser/CServerBrowser.h"
 #include "options/adv_options_dialog.h"
@@ -33,7 +34,11 @@ CGameUIViewport::CGameUIViewport()
 	SetParent(g_pEngineVGui->GetPanel(PANEL_GAMEUIDLL));
 	SetScheme(vgui2::scheme()->LoadSchemeFromFile(VGUI2_ROOT_DIR "resource/ClientSourceScheme.res", "ClientSourceScheme"));
 
-	SetSize(0, 0);
+	ComputeGUIScale();
+
+	SetProportional(true);
+
+	SetSize(ScreenWidth, ScreenHeight);
 
 	m_bPrepareForQueryDownload = false;
 	m_hWorkshopInfoBox = nullptr;

--- a/src/game/client/gameui/gameui_viewport.h
+++ b/src/game/client/gameui/gameui_viewport.h
@@ -19,6 +19,8 @@ class CGameUIViewport : public vgui2::EditablePanel
 	DECLARE_CLASS_SIMPLE(CGameUIViewport, vgui2::EditablePanel);
 
 public:
+	static void ComputeGUIScale(); // Scale GUI elements up from 1080p.
+
 	static inline CGameUIViewport *Get()
 	{
 		return m_sInstance;


### PR DESCRIPTION
This PR attempts to resolve the VGUI2 scaling issues on HD displays addressed in #1. The implementation is not finished and therefore a draft.

The CGameUIViewport class is given a new function `ComputeGUIScale`. From 1080p upwards, VGUI2 elements are up-scaled with larger text and elements - however this comes with a few caveats at the time of writing.

1. While text & elements scale, the window sizes do not.
2. When resizing certain windows such as the VGUI2 Server Browser elements are lost.
3. It may not scale "children" panels such as the filebrowser windows created by Workshop Manager.

![202507~3](https://github.com/user-attachments/assets/38e9ce47-7c6a-4f49-95ba-bd6890230ce8)
*The Server Browser appears to be mostly nominal*

![202507~4](https://github.com/user-attachments/assets/6638890b-eb7f-46ec-a86d-6039b9df7d84)
*..until a resize*

![205781~1](https://github.com/user-attachments/assets/0dcc8cc4-1863-4303-b3a6-a2d2eade5422)
*Achievements*

![20D1B8~1](https://github.com/user-attachments/assets/72ab5e7c-acce-406a-b382-0d5d75eec4b2)
*Workshop*