### PR TITLE
Fix Workshop Manager cutting off content when >4 items are displayed

### DIFF
--- a/src/game/client/zp/ui/workshop/CWorkshopSubList.cpp
+++ b/src/game/client/zp/ui/workshop/CWorkshopSubList.cpp
@@ -155,6 +155,10 @@ void CWorkshopSubList::UpdateItems()
 		    item.uWorkshopID
 		);
 	}
+
+	// Redraw the layout so >4 items are visible + scrollbar
+	pList->InvalidateLayout(true);
+	pList->Repaint();
 }
 
 bool CWorkshopSubList::HasFilterFlag( int iFilters )


### PR DESCRIPTION
Prior to this change there was an issue where the workshop manager would cut off if there was >4 items displayed in the list, until the user clicked one of the scrollbar buttons.