### PR TITLE
Fix pre-round gameplay input carryover

### DIFF
--- a/src/game/client/hud/ammo.cpp
+++ b/src/game/client/hud/ammo.cpp
@@ -38,6 +38,7 @@
 ConVar hud_fastswitch("hud_fastswitch", "0", FCVAR_ARCHIVE, "Controls whether or not weapons can be selected in one keypress");
 ConVar hud_weaponslot_corner_hug("hud_weaponslot_corner_hug", "0", FCVAR_BHL_ARCHIVE, "Hug the weapon slots to the left of the screen");
 extern ConVar cl_cross_zoom;
+extern bool HasRoundBegun();
 
 WEAPON *gpActiveSel; // NULL means off, 1 means just the menu bar, otherwise
     // this points to the active weapon menu item
@@ -51,6 +52,14 @@ WeaponsResource gWR;
 int g_ActiveAmmoIndex = 0;
 
 int g_weaponselect = 0;
+
+void HudAmmo_ClearWeaponSelectionInputState()
+{
+	gpActiveSel = NULL;
+	gpLastSel = NULL;
+	g_weaponselect = 0;
+	gHUD.m_iKeyBits &= ~IN_ATTACK;
+}
 
 #define SET_WEAPON_SELECTION_XPOS 180
 #define SET_WEAPON_SELECTION_YPOS 20
@@ -258,6 +267,12 @@ void CHudAmmo::Think(void)
 	// has the player selected one?
 	if (gHUD.m_iKeyBits & IN_ATTACK || hud_fastswitch.GetInt() == 2)
 	{
+		if ( !HasRoundBegun() )
+		{
+			HudAmmo_ClearWeaponSelectionInputState();
+			return;
+		}
+
 		if (gpActiveSel != (WEAPON *)1)
 		{
 			ServerCmd(gpActiveSel->szName);
@@ -582,13 +597,16 @@ void CHudAmmo::SlotInput(int iSlot)
 	if (g_pViewport && g_pViewport->SlotInput(iSlot))
 		return;
 
+	if ( !HasRoundBegun() )
+	{
+		HudAmmo_ClearWeaponSelectionInputState();
+		return;
+	}
+
 	// Tell the server we selected this weapon slot
 	char szCmd[16];
 	Q_snprintf(szCmd, sizeof(szCmd), "slot %d", iSlot );
 	ServerCmd(szCmd);
-
-	// Old stuff from HL1, not used anymore
-	//gWR.SelectSlot(iSlot, FALSE, 1);
 }
 
 void CHudAmmo::UserCmd_Slot1(void)

--- a/src/game/client/input.cpp
+++ b/src/game/client/input.cpp
@@ -36,6 +36,7 @@ extern bool g_bLocalPlayerIsValid;
 
 extern int g_weaponselect;
 extern cl_enginefunc_t gEngfuncs;
+extern void HudAmmo_ClearWeaponSelectionInputState();
 
 bool g_bDecentJumped = false;
 bool g_bLongJumped = false;
@@ -44,6 +45,7 @@ bool g_bBunnyhopJumped = false;
 void IN_Init(void);
 void IN_Move(float frametime, usercmd_t *cmd);
 void IN_Shutdown(void);
+void Input_ClearAttackState();
 void V_Init(void);
 void VectorAngles(const float *forward, float *angles);
 int CL_ButtonBits(int);
@@ -511,7 +513,11 @@ void IN_LeftUp(void) { KeyUp(&in_left); }
 void IN_RightDown(void) { KeyDown(&in_right); }
 void IN_RightUp(void) { KeyUp(&in_right); }
 void IN_DucktapUp(void) { KeyUp(&in_ducktap); }
-void IN_DucktapDown(void) { KeyDown(&in_ducktap); }
+void IN_DucktapDown(void)
+{
+	if ( !HasRoundBegun() ) return;
+	KeyDown(&in_ducktap);
+}
 
 
 void IN_VoiceWheelUp(void)
@@ -619,7 +625,11 @@ void IN_JumpDown(void)
 	CHudSpectator::Get()->HandleButtonsDown(IN_JUMP);
 }
 void IN_JumpUp(void) { KeyUp(&in_jump); }
-void IN_LongJumpDown(void) { KeyDown(&in_longjump); }
+void IN_LongJumpDown(void)
+{
+	if ( !HasRoundBegun() ) return;
+	KeyDown(&in_longjump);
+}
 void IN_LongJumpUp(void) { KeyUp(&in_longjump); }
 void IN_DuckDown(void)
 {
@@ -628,9 +638,17 @@ void IN_DuckDown(void)
 	CHudSpectator::Get()->HandleButtonsDown(IN_DUCK);
 }
 void IN_DuckUp(void) { KeyUp(&in_duck); }
-void IN_ReloadDown(void) { KeyDown(&in_reload); }
+void IN_ReloadDown(void)
+{
+	if ( !HasRoundBegun() ) return;
+	KeyDown(&in_reload);
+}
 void IN_ReloadUp(void) { KeyUp(&in_reload); }
-void IN_UnloadDown(void) { KeyDown(&in_unload); }
+void IN_UnloadDown(void)
+{
+	if ( !HasRoundBegun() ) return;
+	KeyDown(&in_unload);
+}
 void IN_UnloadUp(void) { KeyUp(&in_unload); }
 void IN_GraphDown(void) { KeyDown(&in_graph); }
 void IN_GraphUp(void) { KeyUp(&in_graph); }
@@ -656,6 +674,7 @@ void IN_Cancel(void)
 
 void IN_Impulse(void)
 {
+	if ( !HasRoundBegun() ) return;
 	in_impulse = atoi(gEngfuncs.Cmd_Argv(1));
 }
 
@@ -687,7 +706,7 @@ void IN_MLookUp(void)
 }
 
 // Make sure we clear all input states
-// We don't want the player to keep moving if we force thenm to stop!
+// We don't want blocked gameplay input to carry across round transitions.
 void Input_ClearInputState( kbutton_t *button )
 {
 	button->down[0] = 0;
@@ -711,6 +730,19 @@ void Input_StopAllMovements( bool bForce )
 	Input_ClearInputState(&in_up);
 	Input_ClearInputState(&in_duck);
 	Input_ClearInputState(&in_jump);
+	Input_ClearInputState(&in_longjump);
+	Input_ClearInputState(&in_use);
+	Input_ClearAttackState();
+	Input_ClearInputState(&in_reload);
+	Input_ClearInputState(&in_unload);
+	Input_ClearInputState(&in_ducktap);
+	in_impulse = 0;
+	in_cancel = 0;
+	g_bDecentJumped = false;
+	g_bLongJumped = false;
+	g_bBunnyhopJumped = false;
+	HudAmmo_ClearWeaponSelectionInputState();
+	gHUD.m_iKeyBits &= ~(IN_FORWARD | IN_BACK | IN_MOVELEFT | IN_MOVERIGHT | IN_JUMP | IN_DUCK | IN_ATTACK | IN_ATTACK2 | IN_USE | IN_RELOAD | IN_UNLOAD);
 }
 
 void Input_ClearAttackState()
@@ -718,7 +750,6 @@ void Input_ClearAttackState()
 	Input_ClearInputState(&in_attack);
 	Input_ClearInputState(&in_attack2);
 }
-
 /*
 ===============
 CL_KeyState

--- a/src/game/client/inputw32.cpp
+++ b/src/game/client/inputw32.cpp
@@ -47,6 +47,7 @@ enum class MouseMode
 
 extern cl_enginefunc_t gEngfuncs;
 extern int iMouseInUse;
+extern bool HasRoundBegun();
 
 extern kbutton_t in_strafe;
 extern kbutton_t in_mlook;
@@ -889,7 +890,10 @@ void IN_MouseMove(float frametime, usercmd_t *cmd)
 
 		// add mouse X/Y movement to cmd
 		if ((in_strafe.state & 1) || (lookstrafe->value && (in_mlook.state & 1)))
-			cmd->sidemove += m_side->value * mouse_x;
+		{
+			if ( HasRoundBegun() )
+				cmd->sidemove += m_side->value * mouse_x;
+		}
 		else
 			viewangles[YAW] -= m_yaw->value * mouse_x;
 
@@ -905,11 +909,13 @@ void IN_MouseMove(float frametime, usercmd_t *cmd)
 		{
 			if ((in_strafe.state & 1) && gEngfuncs.IsNoClipping())
 			{
-				cmd->upmove -= m_forward->value * mouse_y;
+				if ( HasRoundBegun() )
+					cmd->upmove -= m_forward->value * mouse_y;
 			}
 			else
 			{
-				cmd->forwardmove -= m_forward->value * mouse_y;
+				if ( HasRoundBegun() )
+					cmd->forwardmove -= m_forward->value * mouse_y;
 			}
 		}
 
@@ -1302,6 +1308,7 @@ void IN_JoyMove(float frametime, usercmd_t *cmd)
 		speed = 1;
 
 	aspeed = speed * frametime;
+	const bool bCanMove = HasRoundBegun();
 
 	// loop through the axes
 	for (i = 0; i < JOY_MAX_AXES; i++)
@@ -1363,7 +1370,7 @@ void IN_JoyMove(float frametime, usercmd_t *cmd)
 			else
 			{
 				// user wants forward control to be forward control
-				if (fabs(fAxisValue) > joy_forwardthreshold->value)
+				if (bCanMove && fabs(fAxisValue) > joy_forwardthreshold->value)
 				{
 					cmd->forwardmove += (fAxisValue * joy_forwardsensitivity->value) * speed * GetMaxPossibleSpeed( ZPPlayerMovementDirection_t::DirForward );
 				}
@@ -1371,7 +1378,7 @@ void IN_JoyMove(float frametime, usercmd_t *cmd)
 			break;
 
 		case AxisSide:
-			if (fabs(fAxisValue) > joy_sidethreshold->value)
+			if (bCanMove && fabs(fAxisValue) > joy_sidethreshold->value)
 			{
 				cmd->sidemove += (fAxisValue * joy_sidesensitivity->value) * speed * GetMaxPossibleSpeed( ZPPlayerMovementDirection_t::DirSides );
 			}
@@ -1381,7 +1388,7 @@ void IN_JoyMove(float frametime, usercmd_t *cmd)
 			if ((in_strafe.state & 1) || (lookstrafe->value && (in_jlook.state & 1)))
 			{
 				// user wants turn control to become side control
-				if (fabs(fAxisValue) > joy_sidethreshold->value)
+				if (bCanMove && fabs(fAxisValue) > joy_sidethreshold->value)
 				{
 					cmd->sidemove -= (fAxisValue * joy_sidesensitivity->value) * speed * GetMaxPossibleSpeed( ZPPlayerMovementDirection_t::DirSides );
 				}

--- a/src/game/server/observer.cpp
+++ b/src/game/server/observer.cpp
@@ -86,6 +86,7 @@ void CBasePlayer::StartObserver(void)
 	ClearBits(pev->flags, FL_DUCKING);
 	pev->deadflag = DEAD_RESPAWNABLE;
 	pev->health = 1;
+	g_engfuncs.pfnSetPhysicsKeyValue( edict(), "zprl", "0" );
 
 	// Clear out the status bar
 	m_fInitHUD = TRUE;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -70,6 +70,28 @@ static bool SpawnAnimatedPlayerCorpse(CBasePlayer *pPlayer);
 
 static constexpr int PLAYER_CORPSE_ANIM_MARKER = 31337;
 
+namespace
+{
+bool CanProcessRoundGameplayInput( const CBasePlayer *pPlayer )
+{
+	if ( !pPlayer ) return false;
+	return ZP::GetCurrentRoundState() == ZP::RoundState::RoundState_RoundHasBegun;
+}
+
+void UpdateRoundInputLockPhysicsKey( CBasePlayer *pPlayer )
+{
+	if ( !pPlayer ) return;
+
+	const bool bShouldLock = pPlayer->IsConnected()
+		&& pPlayer->IsAlive()
+		&& !pPlayer->IsObserver()
+		&& pPlayer->pev->team != ZP::TEAM_OBSERVER
+		&& ZP::GetCurrentRoundState() != ZP::RoundState::RoundState_RoundHasBegun;
+
+	g_engfuncs.pfnSetPhysicsKeyValue( pPlayer->edict(), "zprl", bShouldLock ? "1" : "0" );
+}
+}
+
 // the world node graph
 extern CGraph WorldGraph;
 
@@ -2094,6 +2116,7 @@ void CBasePlayer::StartWelcomeCam(void)
 	pev->deadflag = DEAD_RESPAWNABLE;
 	pev->effects = EF_NODRAW; // Hide model. This is used instead of pev->modelindex = 0
 	pev->team = ZP::TEAM_OBSERVER;
+	g_engfuncs.pfnSetPhysicsKeyValue( edict(), "zprl", "0" );
 
 	if ( ZPGameRules() )
 		ZPGameRules()->SendPlayerTeamInfo( this );
@@ -2283,6 +2306,9 @@ CBaseEntity *CBasePlayer::FindUseEntity()
 
 void CBasePlayer::PlayerUse(void)
 {
+	if ( !CanProcessRoundGameplayInput( this ) )
+		return;
+
 	// Was use pressed or released?
 	if (!((pev->button | m_afButtonPressed | m_afButtonReleased) & IN_USE))
 		return;
@@ -5017,6 +5043,7 @@ void CBasePlayer::Spawn(void)
 
 	g_engfuncs.pfnSetPhysicsKeyValue(edict(), "slj", "0");
 	g_engfuncs.pfnSetPhysicsKeyValue(edict(), "hl", "1");
+	UpdateRoundInputLockPhysicsKey( this );
 
 	pev->fov = m_iFOV = 0; // init field of view.
 	m_iClientFOV = -1; // make sure fov reset is sent
@@ -5300,7 +5327,11 @@ void CBasePlayer::SelectNextItem(int iItem)
 
 void CBasePlayer::SelectItem(const char *pstr)
 {
-	if (!pstr) return;
+	if ( !CanProcessRoundGameplayInput( this ) )
+		return;
+
+	if (!pstr)
+		return;
 	if ( !CanSelectNewWeapon( true ) ) return;
 
 	CBasePlayerItem *pItem = NULL;
@@ -5333,6 +5364,9 @@ void CBasePlayer::SelectItem(const char *pstr)
 
 void CBasePlayer::SelectLastItem(void)
 {
+	if ( !CanProcessRoundGameplayInput( this ) )
+		return;
+
 	if ( !m_pLastItem ) return;
 	if ( m_pActiveItem && !m_pActiveItem->CanHolster() ) return;
 	if ( !CanSelectNewWeapon( true ) ) return;
@@ -5621,6 +5655,12 @@ ImpulseCommands
 
 void CBasePlayer::ImpulseCommands()
 {
+	if ( !CanProcessRoundGameplayInput( this ) )
+	{
+		pev->impulse = 0;
+		return;
+	}
+
 	TraceResult tr; // UNDONE: kill me! This is temporary for PreAlpha CDs
 
 	// Handle use events
@@ -6056,6 +6096,12 @@ Called every frame by the player PostThink
 void CBasePlayer::ItemPostFrame()
 {
 	static int fInSelect = FALSE;
+
+	if ( !CanProcessRoundGameplayInput( this ) )
+	{
+		pev->impulse = 0;
+		return;
+	}
 
 	// check if the player is using a tank
 	if (m_pTank != NULL)

--- a/src/game/server/zp/gamemodes/zp_gamemodebase.cpp
+++ b/src/game/server/zp/gamemodes/zp_gamemodebase.cpp
@@ -25,6 +25,41 @@
 static IGameModeBase *s_GameModeBase = nullptr;
 extern ConVar sv_fafo_only;
 
+namespace
+{
+bool ShouldRoundLockPlayerInput( CBasePlayer *pPlayer, ZP::RoundState state )
+{
+	if ( !pPlayer ) return false;
+	if ( !pPlayer->IsConnected() ) return false;
+	if ( !pPlayer->IsAlive() ) return false;
+	if ( pPlayer->IsObserver() ) return false;
+	if ( pPlayer->pev->team == ZP::TEAM_OBSERVER ) return false;
+	return state != ZP::RoundState::RoundState_RoundHasBegun;
+}
+
+void UpdateRoundInputLockForPlayer( CBasePlayer *pPlayer, ZP::RoundState state )
+{
+	if ( !pPlayer ) return;
+	g_engfuncs.pfnSetPhysicsKeyValue( pPlayer->edict(), "zprl", ShouldRoundLockPlayerInput( pPlayer, state ) ? "1" : "0" );
+}
+
+void UpdateRoundInputLockForAllPlayers( ZP::RoundState state )
+{
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+	{
+		CBasePlayer *pPlayer = (CBasePlayer *)UTIL_PlayerByIndex( i );
+		if ( !pPlayer ) continue;
+		UpdateRoundInputLockForPlayer( pPlayer, state );
+	}
+}
+}
+
+void IGameModeBase::SetRoundState( ZP::RoundState state )
+{
+	m_iRoundState = state;
+	UpdateRoundInputLockForAllPlayers( state );
+}
+
 IGameModeBase *ZP::GetCurrentGameMode()
 {
 	return s_GameModeBase;

--- a/src/game/server/zp/gamemodes/zp_gamemodebase.h
+++ b/src/game/server/zp/gamemodes/zp_gamemodebase.h
@@ -37,7 +37,7 @@ public:
 	virtual void GiveWeapons(CBasePlayer *pPlayer) = 0;
 
 	// Roundstate
-	void SetRoundState( ZP::RoundState state ) { m_iRoundState = state; }
+	void SetRoundState( ZP::RoundState state );
 	ZP::RoundState GetRoundState() const { return m_iRoundState; }
 	virtual void OnRoundStateThink( ZP::RoundState state ) {};
 

--- a/src/game/shared/zp/weapons/CWeaponBase.cpp
+++ b/src/game/shared/zp/weapons/CWeaponBase.cpp
@@ -3,6 +3,7 @@
 #include "CWeaponBase.h"
 #ifndef CLIENT_DLL
 #include "gamerules.h"
+#include "zp/gamemodes/zp_gamemodebase.h"
 #endif
 
 /// <summary>
@@ -277,6 +278,11 @@ void CWeaponBase::ItemPostFrame( void )
 
 	if ( m_bIsUnloading )
 		FinishUnloading();
+
+#ifndef CLIENT_DLL
+	if ( ZP::GetCurrentRoundState() != ZP::RoundState::RoundState_RoundHasBegun )
+		return;
+#endif
 
 	if ((m_fInReload) && (pPlayer->m_flNextAttack <= UTIL_WeaponTimeBase()))
 	{

--- a/src/pm_shared/pm_shared.cpp
+++ b/src/pm_shared/pm_shared.cpp
@@ -3260,6 +3260,7 @@ void PM_CheckParamters(void)
 	float spd;
 	float maxspeed;
 	Vector v_angle;
+	const bool bRoundInputLocked = atoi( pmove->PM_Info_ValueForKey( pmove->physinfo, "zprl" ) ) == 1;
 
 	spd = (pmove->cmd.forwardmove * pmove->cmd.forwardmove) + (pmove->cmd.sidemove * pmove->cmd.sidemove) + (pmove->cmd.upmove * pmove->cmd.upmove);
 	spd = sqrt(spd);
@@ -3274,7 +3275,7 @@ void PM_CheckParamters(void)
 	//
 	// JoshA: Moved this to CheckParamters rather than working on the velocity,
 	// as otherwise it affects every integration step incorrectly.
-	if (PM_GetActualUseSlowDownType() == EUseSlowDownType::New && (pmove->onground != -1) && (pmove->cmd.buttons & IN_USE))
+	if (!bRoundInputLocked && PM_GetActualUseSlowDownType() == EUseSlowDownType::New && (pmove->onground != -1) && (pmove->cmd.buttons & IN_USE))
 	{
 		pmove->maxspeed *= 1.0f / 3.0f;
 	}
@@ -3287,11 +3288,16 @@ void PM_CheckParamters(void)
 		pmove->cmd.upmove *= fRatio;
 	}
 
-	if (pmove->flags & FL_FROZEN || pmove->flags & FL_ONTRAIN || pmove->dead)
+	if (pmove->flags & FL_FROZEN || pmove->flags & FL_ONTRAIN || pmove->dead || bRoundInputLocked)
 	{
 		pmove->cmd.forwardmove = 0;
 		pmove->cmd.sidemove = 0;
 		pmove->cmd.upmove = 0;
+	}
+
+	if (bRoundInputLocked)
+	{
+		pmove->cmd.buttons &= ~(IN_FORWARD | IN_BACK | IN_MOVELEFT | IN_MOVERIGHT | IN_JUMP | IN_DUCK | IN_ATTACK | IN_ATTACK2 | IN_USE | IN_RELOAD | IN_UNLOAD);
 	}
 
 	PM_DropPunchAngle(pmove->punchangle);


### PR DESCRIPTION
## Issue
Players could exploit the round boundary by holding or generating input before the round was live, then acting immediately when controls unlocked. This change closes that gap comprehensively and moves enforcement to the server so modified clients cannot bypass it.

I noticed multiple players exploiting this to rush objectives or get favorable positions as a zombie before the vast majority of players could move.

## Summary
- block gameplay-affecting input until the round reaches `RoundState_RoundHasBegun`
- prevent held inputs from carrying across round boundaries and firing on the first live frame
- preserve observer movement while enforcing server-authoritative protection against stock-client, analog, and modified-client pre-round input

## Details
- add a server-driven round input lock that updates player physics state on round-state changes
- strip pre-round movement and gameplay button input in shared movement code
- guard server gameplay consumers for use, impulses, weapon post-frame actions, and weapon selection
- clear client gameplay input state at round transitions, including attack/use/reload/unload, impulses, and pending weapon selection
- block pre-round analog movement and stock-client weapon slot selection/unload behavior

## Verification
- built `client.dll` and `zp.dll` successfully with:
```text
cmake --build build --config Release --target client zp
```
- rebuilt `client.dll` after restoring the missing `IN_UnloadDown` round-state guard with:
```text
cmake --build build --config Release --target client
```
- audited the affected client, server, shared movement, and weapon paths to confirm:
  - pre-round movement is rejected
  - held inputs do not carry across rounds
  - weapon selection/use/reload/unload are blocked until the live round
  - observer movement remains available

- Unable to test directly due to missing .mdl files due to recently added items (cz75/sks etc.), decided to pursue anyways due to how much the exploit ruins game play.